### PR TITLE
Update from a depricated chat model and version in Bicep file

### DIFF
--- a/Allfiles/Labs/Shared/deploy.aoai-deployments.bicep
+++ b/Allfiles/Labs/Shared/deploy.aoai-deployments.bicep
@@ -11,10 +11,10 @@ param embeddingModelVersion string = '2'
 param embeddingCapacity int = 1
 
 @description('Chat model to deploy.')
-param chatModelName string = 'gpt-4o-mini'
+param chatModelName string = 'gpt-5-mini'
 
 @description('Chat model version.')
-param chatModelVersion string = '2024-07-18'
+param chatModelVersion string = '2025-08-07'
 
 @description('Capacity for chat deployment (keep small for labs).')
 param chatCapacity int = 1


### PR DESCRIPTION
GPT-4o-mini has been depricated since 31-5-2026, suggesting an update to a newer model

# Module: RAG applications with Azure Database for PostgreSQL
## Lab: 17-build-rag-application-postgresql-python

Fixes # .

Changes proposed in this pull request:
In the bicep file:
Update depricated model from GPT-4o-mini to GPT-5-mini
Update the model version from 2024-07-18 to 2025-08-07
-
-
-